### PR TITLE
make nlb fully dependent on underlying network

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,6 +5,7 @@ module "network" {
   public_subnets_cidrs  = var.public_subnets_cidrs
   private_subnets_cidrs = var.private_subnets_cidrs
   name_prefix           = var.name_prefix
+  lb_internal           = var.lb_internal
   common_tags           = var.common_tags
 
 }

--- a/terraform/network/nlb.tf
+++ b/terraform/network/nlb.tf
@@ -1,10 +1,14 @@
 resource "aws_lb" "ptfe" {
   name_prefix                      = "ptfe-" # using hardcoded prefix because of length limitatoin to 6 chars
   load_balancer_type               = "network"
-  internal                         = false
+  internal                         = var.lb_internal
   subnets                          = module.ptfe-network.public_subnet_ids
   enable_cross_zone_load_balancing = true
   tags                             = var.common_tags
+
+  depends_on = [
+    module.ptfe-network # ensure that the underlying network resources are fully created before creating the balancer.
+  ]
 }
 
 resource "aws_lb_listener" "port_80" {

--- a/terraform/network/variables.tf
+++ b/terraform/network/variables.tf
@@ -15,6 +15,12 @@ variable "private_subnets_cidrs" {
 
 }
 
+variable "lb_internal" {
+  type        = bool
+  description = "Whether to create internal load balancer."
+  default     = false
+}
+
 variable "name_prefix" {
   type        = string
   description = "A string to be used as prefix for generating names of the created resources"

--- a/terraform/variables.network.tf
+++ b/terraform/variables.network.tf
@@ -14,3 +14,9 @@ variable "private_subnets_cidrs" {
   description = "Map containing the private subnets CIDRs as keys and number as value. The number is used to determine the AWS vailability zone in which the subnet will be created. It is used as an list index to select an AZ in the current AWS region. The map must contain atleast two key/value pairs."
 
 }
+
+variable "lb_internal" {
+  type        = bool
+  description = "Whether to create internal load balancer."
+  default     = false
+}


### PR DESCRIPTION
There is no implicit dependency between the VPC internet gateway and the load balancer.

In case the load balancer is not internal and its creation is attempted before the VPC has attached internet gateway to it the load balancer creation will fail. 